### PR TITLE
Adding resolve() call

### DIFF
--- a/source/Pict-Router.js
+++ b/source/Pict-Router.js
@@ -1,6 +1,5 @@
 const libPictProvider = require('pict-provider');
 const libNavigo = require('navigo');
-const {ResolveOptions} = require("navigo");
 
 const _DEFAULT_PROVIDER_CONFIGURATION =
 {

--- a/source/Pict-Router.js
+++ b/source/Pict-Router.js
@@ -1,5 +1,6 @@
 const libPictProvider = require('pict-provider');
 const libNavigo = require('navigo');
+const {ResolveOptions} = require("navigo");
 
 const _DEFAULT_PROVIDER_CONFIGURATION =
 {
@@ -65,6 +66,7 @@ class PictRouter extends libPictProvider
 		if (typeof(pRenderable) === 'function')
 		{
 			this.router.on(pRoute, pRenderable);
+			this.resolve();
 		}
 		else if (typeof(pRenderable) === 'string')
 		{
@@ -74,6 +76,7 @@ class PictRouter extends libPictProvider
 				{
 					this.pict.parseTemplate(pRenderable, pData, null, this.pict)
 				});
+			this.resolve();
 		}
 		else
 		{
@@ -90,6 +93,14 @@ class PictRouter extends libPictProvider
 	navigate(pRoute)
 	{
 		this.router.navigate(pRoute);
+	}
+
+	/**
+	 * Trigger the router resolving logic
+	 *
+	 */
+	resolve() {
+		this.router.resolve();
 	}
 }
 


### PR DESCRIPTION
Adding resolve() call after adding a route to navigo so the router will properly interpret routes navigated to directly through url. It looks like `resolve()` is called automatically as part of the `navigate` action, but if we go to a page directly via clicking a hyper link, for example, the `resolve` never happens and so the route isn't matched.

From navigo readme:

  The constructor of the library accepts a single argument - the root path of your app. If you host your project at https://site.com/my/awesome/app, your root path is /my/awesome/app. Then you have to define your routes.
```  
  router.on('/my/awesome/app', function () {
    // do something
  });
```
  At the end you have to trigger the resolving logic:
  
 ` router.resolve();`

More info: https://github.com/krasimir/navigo/blob/master/DOCUMENTATION.md#resolving-routes